### PR TITLE
Add function to expose set_outer_position

### DIFF
--- a/src/backend/window.rs
+++ b/src/backend/window.rs
@@ -9,8 +9,8 @@ use crate::ImageInfo;
 use crate::ImageView;
 use crate::WindowId;
 use crate::WindowProxy;
-use glam::Vec3;
-use glam::{Affine2, Vec2};
+use glam::{Affine2, IVec2, Vec2, Vec3};
+use winit::dpi::PhysicalPosition;
 
 /// Internal shorthand for window event handlers.
 type DynWindowEventHandler = dyn FnMut(WindowHandle, &mut WindowEvent, &mut EventHandlerControlFlow);
@@ -167,8 +167,8 @@ impl<'a> WindowHandle<'a> {
 	}
 
 	/// Set the window position.
-	pub fn set_outer_position<P: Into<winit::dpi::Position>>(&self, position: P) {
-		self.window().window.set_outer_position(position);
+	pub fn set_outer_position(&self, position: IVec2) {
+		self.window().window.set_outer_position(PhysicalPosition::new(position.x, position.y));
 		self.window().window.request_redraw();
 	}
 

--- a/src/backend/window.rs
+++ b/src/backend/window.rs
@@ -166,6 +166,12 @@ impl<'a> WindowHandle<'a> {
 		self.window().window.request_redraw();
 	}
 
+	/// Set the window position.
+	pub fn set_outer_position<P: Into<winit::dpi::Position>>(&self, position: P) {
+		self.window().window.set_outer_position(position);
+		self.window().window.request_redraw();
+	}
+
 	/// Get the inner size of the window in physical pixels.
 	///
 	/// This returns the size of the window contents, excluding borders, the title bar and other decorations.

--- a/src/backend/window.rs
+++ b/src/backend/window.rs
@@ -9,8 +9,8 @@ use crate::ImageInfo;
 use crate::ImageView;
 use crate::WindowId;
 use crate::WindowProxy;
-use glam::{Affine2, IVec2, Vec2, Vec3};
-use winit::dpi::PhysicalPosition;
+use glam::Vec3;
+use glam::{Affine2, Vec2};
 
 /// Internal shorthand for window event handlers.
 type DynWindowEventHandler = dyn FnMut(WindowHandle, &mut WindowEvent, &mut EventHandlerControlFlow);
@@ -167,8 +167,8 @@ impl<'a> WindowHandle<'a> {
 	}
 
 	/// Set the window position.
-	pub fn set_outer_position(&self, position: IVec2) {
-		self.window().window.set_outer_position(PhysicalPosition::new(position.x, position.y));
+	pub fn set_outer_position(&self, position: [i32; 2]) {
+		self.window().window.set_outer_position(winit::dpi::PhysicalPosition::<i32>::from(position));
 		self.window().window.request_redraw();
 	}
 


### PR DESCRIPTION
The feature set in this crate was ideal for an application of mine, but the ability to position the resulting window was required.  Perhaps this is useful for others.

This change exposes the set_outer_position function on the winit window.

Beware rust neophyte.