### PR TITLE
Allow setting the title of a window after creation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # main
+  * Add `WindowHandle::set_title()` to update the title of a window.
   * Bump maximum supported version of `tch` to `v0.19.x`.
   * Bump maximum supported version of `glam` to `v0.30.x`.
 

--- a/src/backend/window.rs
+++ b/src/backend/window.rs
@@ -145,6 +145,11 @@ impl<'a> WindowHandle<'a> {
 		context_handle
 	}
 
+	/// Set the title of the window.
+	pub fn set_title(&self, title: impl AsRef<str>) {
+		self.window().window.set_title(title.as_ref());
+	}
+
 	/// Get the image info.
 	///
 	/// Returns [`None`] if no image is set for the window.


### PR DESCRIPTION
Add `WindowHandle::set_title()` to update the window title after creation.

Fixes #48.